### PR TITLE
Fix illegal whitespace in Dockerfile

### DIFF
--- a/CUDA/Dockerfile
+++ b/CUDA/Dockerfile
@@ -23,7 +23,7 @@ ENV UDEV=1
 
 # Download and install BSP binaries for L4T 32.4.4
 RUN apt-get update && apt-get install -y wget tar lbzip2 python3 libegl1 && \
-    wget https://developer.nvidia.com/embedded/L4T/r32_Release_v4.4/r32_Release_v4.4-GMC3/T210/Tegra210_Linux_R32.4.4_aarch64.tbz2 && \       
+    wget https://developer.nvidia.com/embedded/L4T/r32_Release_v4.4/r32_Release_v4.4-GMC3/T210/Tegra210_Linux_R32.4.4_aarch64.tbz2 && \
     tar xf Tegra210_Linux_R32.4.4_aarch64.tbz2 && \
     cd Linux_for_Tegra && \
     sed -i 's/config.tbz2\"/config.tbz2\" --exclude=etc\/hosts --exclude=etc\/hostname/g' apply_binaries.sh && \


### PR DESCRIPTION
I followed the instructions from the [recent blog post](https://www.balena.io/blog/how-to-use-nvidia-jetson-devices-on-balenaos/): I executed `$ balena push mydevice.local` and it finished (after a long time) with the following error message, indicating that the last part of `./CUDA/Dockerfile` is the issue (everything else up until that point worked fine):

```
Some services failed to build:
    cuda: The command '/bin/sh -c apt-get update && apt-get install -y wget tar lbzip2 python3 libegl1 &&     wget https://developer.nvidia.com/embedded/L4T/r32_Release_v4.4/r32_Release_v4.4-GMC3/T210/Tegra210_Linux_R32.4.4_aarch64.tbz2 &&     tar xf Tegra210_Linux_R32.4.4_aarch64.tbz2 &&     cd Linux_for_Tegra &&     sed -i 's/config.tbz2\"/config.tbz2\" --exclude=etc\/hosts --exclude=etc\/hostname/g' apply_binaries.sh &&     sed -i 's/install --owner=root --group=root \"${QEMU_BIN}\" \"${L4T_ROOTFS_DIR}\/usr\/bin\/\"/#install --owner=root --group=root \"${QEMU_BIN}\" \"${L4T_ROOTFS_DIR}\/usr\/bin\/\"/g' nv_tegra/nv-apply-debs.sh &&     sed -i 's/LC_ALL=C chroot . mount -t proc none \/proc/ /g' nv_tegra/nv-apply-debs.sh &&     sed -i 's/umount ${L4T_ROOTFS_DIR}\/proc/ /g' nv_tegra/nv-apply-debs.sh &&     sed -i 's/chroot . \//  /g' nv_tegra/nv-apply-debs.sh &&     ./apply_binaries.sh -r / --target-overlay && cd ..     rm -rf Tegra210_Linux_R32.4.4_aarch64.tbz2 &&     rm -rf Linux_for_Tegra &&     echo "/usr/lib/aarch64-linux-gnu/tegra" > /etc/ld.so.conf.d/nvidia-tegra.conf && ldconfig' returned a non-zero code: 2
```

The logs didn't say anything more than that but as far as I can tell, the issue is not with any of the subcommands but with the whitespace at the end of line 26 of `./CUDA/Dockerfile`. After removing the whitespace, `balena push` completes successfully.
